### PR TITLE
fix: Unavailable mark `@avaliable`  in Xcode 15

### DIFF
--- a/Sources/MagicTimer/MagicTimer.swift
+++ b/Sources/MagicTimer/MagicTimer.swift
@@ -91,18 +91,18 @@ public class MagicTimer {
     private var backgroundCalculator: MagicTimerBackgroundCalculatorInterface
 
     // MARK: - Unavailable
-    @available(*, unavailable, renamed: "elapsedTimeDidChangeHandler")
-    /// A elpsed time that can observe
+    /// A elapsed time that can observe
+    /// - Warning: renamed: "elapsedTimeDidChangeHandler"
     public var observeElapsedTime: ((TimeInterval) -> Void)?
     
-    @available(*, unavailable, renamed: "lastState")
     /// The current state of the timer.
+    /// - Warning: renamed: "lastState"
     public var currentState: MagicTimerState {
         return lastState
     }
     
-    @available(*, unavailable, renamed: "lastStateDidChangeHandler")
     /// Timer state callback
+    /// - Warning: renamed: "lastStateDidChangeHandler"
     public var didStateChange: ((MagicTimerState) -> Void)?
     
     // MARK: - Constructors


### PR DESCRIPTION
Stored properties in Swift can’t have type information that is potentially unavailable at runtime. However, prior to Swift 5.7 the compiler incorrectly accepted @available attributes on stored properties when the property had either the lazy modifier or an attached property wrapper. This could lead to crashes for apps running on older operating systems. The Swift compiler now consistently rejects @available on all stored properties.